### PR TITLE
Add colors to sass variables, add SASS_PATH var

### DIFF
--- a/client/.env.development
+++ b/client/.env.development
@@ -1,0 +1,2 @@
+export SASS_PATH=node_modules:src/sass
+

--- a/client/package.json
+++ b/client/package.json
@@ -34,7 +34,7 @@
     "typescript": "^3.7.2"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "SASS_PATH='node_modules:src/sass' react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/client/src/components/App.scss
+++ b/client/src/components/App.scss
@@ -1,4 +1,5 @@
 @import-normalize;
+@import "variables.scss";
 @import "./variables.scss";
 @import "./main/splash.scss";
 @import "./main/top_bar/topBar.scss";

--- a/client/src/components/variables.scss
+++ b/client/src/components/variables.scss
@@ -1,1 +1,0 @@
-$border-radius: 6px;

--- a/client/src/sass/variables.scss
+++ b/client/src/sass/variables.scss
@@ -1,0 +1,22 @@
+/* Color */
+$primary:           #3c2d17;
+$primary-dark:      #342610;
+$primary-light:     #44341e;
+
+$secondary:         #f8bbd0;
+$secondary-dark:    #c48b9f;
+$secondary-light:   #ffeeff;
+
+$surface:           #F5F5F6;
+
+$foreground:        #ebdbb2;
+$foreground-dark:   #d5c4a1;
+$foreground-light:  #fbf1c7;
+
+$background:        #565149;
+$background-dark:   #1a1d21;
+$background-light:  #FFFFFF;
+
+/* Borders */
+$border-radius: 6px;
+


### PR DESCRIPTION
You should now be able to import variables with an absolute path, `@import "variables.scss";` should import the variables file regardless of where its called, for this to work you have to make sure you are running `npm start` in the client folder, where the variable declaration is made for you, or you can also create your own global environmental variable of `SASS_PATH` that points to `node_modules` and src/sass