### PR TITLE
Correct title to coffee form, fill modal background, other small tweaks

### DIFF
--- a/client/src/components/main/coffee/CoffeeForm.js
+++ b/client/src/components/main/coffee/CoffeeForm.js
@@ -34,7 +34,7 @@ export default props => {
         onSubmit={values => create({ variables: values })}
       >
         <Form className="coffee-form">
-          <h1>Add a New Coffee Shop</h1>
+          <h1>Add a New Coffee</h1>
           <Field name="name" type="text" placeholder="Coffee Name" />
           <ErrorMessage name="name" />
           <Field name="origin" type="text" placeholder='Origin or "Blend"' />

--- a/client/src/components/main/coffee/CoffeeForm.scss
+++ b/client/src/components/main/coffee/CoffeeForm.scss
@@ -9,7 +9,7 @@
 
 .coffee-form {
   margin: auto;
-  width: 700px;
+  width: 95%;
   display: flex;
   flex-direction: column;
   h1 {


### PR DESCRIPTION
- Corrected "Add Coffee" form title. Was displaying "Add New Coffee Shop"
- Changed width of input on modal form to 95% instead of 700px because on different screen sizes the input fields were jarring out from the side of the form outside the container
- Made html, body, root min-height to 100vh so that the modal background now fills entire screen. Before, it would cutoff at halfway down the page if you start to scroll.