### PR TITLE
Minor paragraph spacing on panel and align index to flex-start

### DIFF
--- a/client/src/components/main/coffee_shop/CoffeeShopIndex.scss
+++ b/client/src/components/main/coffee_shop/CoffeeShopIndex.scss
@@ -44,6 +44,9 @@
   align-items: flex-start;
   flex-direction: column;
   width: 45%;
+  p {
+    line-height: 1.1em;
+  }
 }
 
 .shops-index-div {
@@ -56,7 +59,7 @@
   ul {
     list-style: none;
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
- Fixed awkward presentation of centered lone coffee shop on index to flex-start
- Noticed text was wrapping with no line spacing so added sparse paragraph spacing only on the coffee index panel flavors