### PR TITLE
Fix redundant alt tag in shop panel

### DIFF
--- a/client/src/components/main/coffee_shop/CoffeeShopPanel.js
+++ b/client/src/components/main/coffee_shop/CoffeeShopPanel.js
@@ -11,7 +11,7 @@ export default ({ shop, extraContent }) => {
         <img
           className="shop-panel-image"
           src={shop.imageURL}
-          alt="shop image"
+          alt={`profile for ${ shop.name }`}
         />
         <div className="panel-detail">
           <div className="panel-shop">


### PR DESCRIPTION
Alt tag now references the name of the shop