### PR TITLE
Optimize useOnOutside Click to reduce onEffect calls

### DIFF
--- a/client/src/components/util/useOnOutsideClick.js
+++ b/client/src/components/util/useOnOutsideClick.js
@@ -12,6 +12,8 @@ export default (ref, action) => {
     return () => {
       document.removeEventListener("click", handleClickOutside);
     };
-  });
+  },
+    []
+  );
 }
 


### PR DESCRIPTION
Change the event listener to only be called on mount