### PR TITLE
Major tweak testing script to improve dev quality of life

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "server:debug": "nodemon --ignore client --inspect ./bin/www",
     "frontend-install": "npm install --prefix client",
     "frontend": "npm start --prefix client",
-    "dev": "concurrently \"npm run server:debug\" \"npm run frontend\"",
-    "test": "concurrently -k \"npm run server\" \"npm run frontend \" \"npx cypress run --record false\""
+    "dev": "concurrently \"npm:server:debug\" \"npm:frontend\"",
+    "test": "concurrently -ks first \"npm:server\" \"npm:frontend \" \"npx cypress run --record false\""
   },
   "dependencies": {
     "@types/graphql": "^14.5.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "frontend-install": "npm install --prefix client",
     "frontend": "npm start --prefix client",
     "dev": "concurrently --names \"Server,React\" \"npm:server:debug\" \"npm:frontend\"",
-    "test": "concurrently -ks first \"npm:server\" \"BROWSER=none npm run frontend \" \"npx cypress run --record false\""
+    "test": "concurrently -ks first \"npm:server:production >/dev/null\" \"BROWSER=none npm run frontend >/dev/null\" \"npx cypress run\"",
+    "test:loud": "concurrently --names \"Server,React,Test\" -ks first \"npm:server:production\" \"BROWSER=none npm run frontend \" \"npx cypress run\""
   },
   "dependencies": {
     "@types/graphql": "^14.5.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "server:debug": "nodemon --ignore client --inspect ./bin/www",
     "frontend-install": "npm install --prefix client",
     "frontend": "npm start --prefix client",
-    "dev": "concurrently \"npm:server:debug\" \"npm:frontend\"",
+    "dev": "concurrently --names \"Server,React\" \"npm:server:debug\" \"npm:frontend\"",
     "test": "concurrently -ks first \"npm:server\" \"BROWSER=none npm run frontend \" \"npx cypress run --record false\""
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "frontend-install": "npm install --prefix client",
     "frontend": "npm start --prefix client",
     "dev": "concurrently \"npm:server:debug\" \"npm:frontend\"",
-    "test": "concurrently -ks first \"npm:server\" \"npm:frontend \" \"npx cypress run --record false\""
+    "test": "concurrently -ks first \"npm:server\" \"BROWSER=none npm run frontend \" \"npx cypress run --record false\""
   },
   "dependencies": {
     "@types/graphql": "^14.5.0",


### PR DESCRIPTION
- Test script now returns 1 when they succeed
- Test script no longer floods output with server info (if you want thin extra info you can run `yarn test:loud` or `npm run test:loud`)
- Test script no longer opens `localhost:3000` in browser (this behavior is retained in non-test scripts)
- Dev script now adds names to services so output is a little more clear